### PR TITLE
feat(authentication): add basic auth flow with JWT

### DIFF
--- a/modules/client/src/App.tsx
+++ b/modules/client/src/App.tsx
@@ -57,7 +57,7 @@ function useOnce<T>(fn: () => T): T {
 }
 
 const App = () => {
-  const apiFetch = useOnce(() => new ApiFetch());
+  const apiFetch = useOnce(() => ApiFetch.CreateFromLocalStorage());
   const authManager = useOnce(() => new AuthManager(apiFetch));
   const [isLoaded, setIsLoaded] = useState(false);
 

--- a/modules/client/src/components/auth/button.js
+++ b/modules/client/src/components/auth/button.js
@@ -1,0 +1,46 @@
+import React, { useState, useCallback } from 'react';
+import { Button } from 'semantic-ui-react';
+import { useAuthContext } from './context';
+
+const AuthButton = (props) => {
+  const { fixed } = props;
+  const context = useAuthContext();
+  const [isAuthenticated, setIsAuthenticated] = useState(context.isAuthenticated);
+
+  const loginOnClick = useCallback(async () => {
+    const result = await context.authenticate({ email: 'ben@dirtleague.org', password: 'foobar' });
+
+    setIsAuthenticated(result);
+  }, [context]);
+
+  const signupOnClick = useCallback(async () => {
+    console.log('signup?');
+  }, []);
+
+  const logoutOnClick = useCallback(async () => {
+    const result = await context.logout();
+
+    setIsAuthenticated(!result);
+  }, [context]);
+
+  if (isAuthenticated) {
+    return (
+      <Button as='a' inverted={!fixed} onClick={logoutOnClick}>
+        Log Out
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <Button as='a' inverted={!fixed} onClick={loginOnClick}>
+        Log in
+      </Button>
+      <Button as='a' inverted={!fixed} primary={fixed} style={{ marginLeft: '0.5em' }} onClick={signupOnClick}>
+        Sign Up
+      </Button>
+    </>
+  );
+};
+
+export default AuthButton;

--- a/modules/client/src/components/auth/button.js
+++ b/modules/client/src/components/auth/button.js
@@ -1,6 +1,10 @@
 import React, { useState, useCallback } from 'react';
 import { Button } from 'semantic-ui-react';
 import { useAuthContext } from './context';
+import { RepositoryServices, ApiFetch } from '../../data-access/repositories';
+
+const apiFetch = new ApiFetch();
+const services = new RepositoryServices({ api: apiFetch });
 
 const AuthButton = (props) => {
   const { fixed } = props;
@@ -14,7 +18,7 @@ const AuthButton = (props) => {
   }, [context]);
 
   const signupOnClick = useCallback(async () => {
-    console.log('signup?');
+    await services.getUsers();
   }, []);
 
   const logoutOnClick = useCallback(async () => {
@@ -25,9 +29,14 @@ const AuthButton = (props) => {
 
   if (isAuthenticated) {
     return (
+      <>
       <Button as='a' inverted={!fixed} onClick={logoutOnClick}>
         Log Out
       </Button>
+      <Button as='a' inverted={!fixed} primary={fixed} style={{ marginLeft: '0.5em' }} onClick={signupOnClick}>
+        Sign Up
+      </Button>
+      </>
     );
   }
 

--- a/modules/client/src/components/auth/button.js
+++ b/modules/client/src/components/auth/button.js
@@ -18,13 +18,12 @@ const AuthButton = (props) => {
   }, [context]);
 
   const signupOnClick = useCallback(async () => {
-    await services.getUsers();
+    await services.getUser(1);
   }, []);
 
   const logoutOnClick = useCallback(async () => {
-    const result = await context.logout();
-
-    setIsAuthenticated(!result);
+    await context.logout();
+    setIsAuthenticated(false);
   }, [context]);
 
   if (isAuthenticated) {

--- a/modules/client/src/components/auth/context.js
+++ b/modules/client/src/components/auth/context.js
@@ -1,0 +1,12 @@
+import React, { useContext } from 'react';
+import AuthManager from '../../managers/auth';
+
+const context = React.createContext(new AuthManager());
+
+export default context;
+
+export const useAuthContext = () => {
+  const value = useContext(context);
+
+  return value;
+};

--- a/modules/client/src/data-access/repositories.js
+++ b/modules/client/src/data-access/repositories.js
@@ -1,10 +1,11 @@
 export class ApiFetch {
+  jwt = null;
   // TODO: make this configurable and work by getting the window's current scheme.
   baseUrl = `${window.location.protocol}//127.0.0.1:8081`;
   defaultRequestOptions = {
     mode: 'cors', // no-cors, *cors, same-origin
     cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-    credentials: 'include', // include, *same-origin, omit
+    credentials: 'same-origin', // include, *same-origin, omit
     headers: {
       'Content-Type': 'application/json'
     },
@@ -12,32 +13,63 @@ export class ApiFetch {
     referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
   };
 
+  static CreateFromLocalStorage() {
+    const token = window.localStorage.getItem('DIRTY_TOKEN');
+    const instance = new ApiFetch();
+
+    instance.jwt = token;
+
+    return instance;
+  }
+
   buildUrl = (url) => {
     return `${this.baseUrl}/${url}`;
   };
 
+  buildRequestOptions = (options) => {
+    const reqOptions = {
+      ...this.defaultRequestOptions,
+      ...options,
+    };
+
+    if (this.jwt) {
+      reqOptions.headers['Authorization'] = `Bearer ${this.jwt}`;
+    }
+
+    return reqOptions;
+  };
+
   post = async (url = '', data = {}) => {
     // Default options are marked with *
-    const response = await fetch(this.buildUrl(url), {
-      ...this.defaultRequestOptions,
-      method: 'POST',
-      body: JSON.stringify(data)
-    });
+    const response = await fetch(
+      this.buildUrl(url),
+      this.buildRequestOptions({
+        method: 'POST',
+        body: JSON.stringify(data)
+      })
+    );
 
     return response.json(); // parses JSON response into native JavaScript objects
   };
 
   get = async (url = '') => {
-    const response = await fetch(this.buildUrl(url));
+    const response = await fetch(
+      this.buildUrl(url),
+      this.buildRequestOptions({
+        method: 'GET'
+      })
+    );
 
     return response.json();
   };
 
   delete = async (url = '') => {
-    const response = await fetch(this.buildUrl(url), {
-      ...this.defaultRequestOptions,
-      method: 'DELETE',
-    });
+    const response = await fetch(
+      this.buildUrl(url),
+      this.buildRequestOptions({
+        method: 'DELETE',
+      })
+    );
 
     return response.json();
   };
@@ -54,18 +86,22 @@ export class AuthServices {
   }
 
   auth = async (data) => {
-    const { success } = await this.api.post('auth', data);
+    const { success, token } = await this.api.post('auth', data);
 
     // TODO: when the server returns the user data, store that as well.
     // We'll use that for the auth manager.
+
+    if (token) {
+      this.api.jwt = token;
+      window.localStorage.setItem('DIRTY_TOKEN', token);
+    }
 
     return success;
   };
 
   logout = async () => {
-    const { success } = await this.api.delete('auth');
-
-    return success;
+    window.localStorage.removeItem('DIRTY_TOKEN');
+    this.api.jwt = null;
   };
 
   isAuthenticated = async () => {
@@ -87,6 +123,12 @@ export class RepositoryServices {
 
   getUsers = async () => {
     const result = await this.api.get('users');
+
+    console.log(result);
+  }
+
+  getUser = async (id) => {
+    const result = await this.api.get(`users/${id}`);
 
     console.log(result);
   }

--- a/modules/client/src/data-access/repositories.js
+++ b/modules/client/src/data-access/repositories.js
@@ -1,7 +1,11 @@
+/**
+ * Handles communication between client and server.
+ * TODO: Have it look for invalid JWTs and callback an onUnauthenticated function to reset app state.
+ */
 export class ApiFetch {
   jwt = null;
   // TODO: make this configurable and work by getting the window's current scheme.
-  baseUrl = `${window.location.protocol}//127.0.0.1:8081`;
+  baseUrl = `${window.location.protocol}//localhost:8081`;
   defaultRequestOptions = {
     mode: 'cors', // no-cors, *cors, same-origin
     cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
@@ -74,7 +78,7 @@ export class ApiFetch {
     return response.json();
   };
 }
-
+// TODO: Stop directly applying to local storage, just have it set on fetching class and have that manage state.
 export class AuthServices {
   /** @type {ApiFetch} */
   api = null;
@@ -111,6 +115,7 @@ export class AuthServices {
   };
 }
 
+// TODO: Move users into user repository class.
 export class RepositoryServices {
   /** @type {ApiFetch} */
   api = null;

--- a/modules/client/src/data-access/repositories.js
+++ b/modules/client/src/data-access/repositories.js
@@ -1,0 +1,80 @@
+export class ApiFetch {
+  // TODO: make this configurable and work by getting the window's current scheme.
+  baseUrl = `${window.location.protocol}//localhost:8081`;
+  defaultRequestOptions = {
+    mode: 'cors', // no-cors, *cors, same-origin
+    cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+    credentials: 'same-origin', // include, *same-origin, omit
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    redirect: 'follow', // manual, *follow, error
+    referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+  };
+
+  buildUrl = (url) => {
+    return `${this.baseUrl}/${url}`;
+  };
+
+  post = async (url = '', data = {}) => {
+    // Default options are marked with *
+    const response = await fetch(this.buildUrl(url), {
+      ...this.defaultRequestOptions,
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+
+    return response.json(); // parses JSON response into native JavaScript objects
+  };
+
+  get = async (url = '') => {
+    const response = await fetch(this.buildUrl(url));
+
+    return response.json();
+  };
+
+  delete = async (url = '') => {
+    const response = await fetch(this.buildUrl(url), {
+      ...this.defaultRequestOptions,
+      method: 'DELETE',
+    });
+
+    return response.json();
+  };
+}
+
+export class AuthServices {
+  /** @type {ApiFetch} */
+  api = null;
+
+  constructor(props) {
+    const { api } = props;
+
+    this.api = api;
+  }
+
+  auth = async (data) => {
+    const { success } = await this.api.post('auth', data);
+
+    // TODO: when the server returns the user data, store that as well.
+    // We'll use that for the auth manager.
+
+    return success;
+  };
+
+  logout = async () => {
+    const { success } = await this.api.delete('auth');
+
+    return success;
+  };
+
+  isAuthenticated = async () => {
+    const { isAuthenticated } = await this.api.get('auth');
+
+    return isAuthenticated
+  };
+}
+
+export class RepositoryServices {
+
+}

--- a/modules/client/src/data-access/repositories.js
+++ b/modules/client/src/data-access/repositories.js
@@ -1,10 +1,10 @@
 export class ApiFetch {
   // TODO: make this configurable and work by getting the window's current scheme.
-  baseUrl = `${window.location.protocol}//localhost:8081`;
+  baseUrl = `${window.location.protocol}//127.0.0.1:8081`;
   defaultRequestOptions = {
     mode: 'cors', // no-cors, *cors, same-origin
     cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-    credentials: 'same-origin', // include, *same-origin, omit
+    credentials: 'include', // include, *same-origin, omit
     headers: {
       'Content-Type': 'application/json'
     },
@@ -76,5 +76,18 @@ export class AuthServices {
 }
 
 export class RepositoryServices {
+  /** @type {ApiFetch} */
+  api = null;
 
+  constructor(props) {
+    const { api } = props;
+
+    this.api = api;
+  }
+
+  getUsers = async () => {
+    const result = await this.api.get('users');
+
+    console.log(result);
+  }
 }

--- a/modules/client/src/managers/auth.js
+++ b/modules/client/src/managers/auth.js
@@ -23,13 +23,8 @@ class AuthManager {
   };
 
   logout = async () => {
-    const result = await this.service.logout();
-
-    if (result) {
-      this.isAuthenticated = false;
-    }
-
-    return result;
+    await this.service.logout()
+    this.isAuthenticated = false;
   };
 
   getIsAuthenticated = async () => {

--- a/modules/client/src/managers/auth.js
+++ b/modules/client/src/managers/auth.js
@@ -1,0 +1,44 @@
+import { AuthServices } from '../data-access/repositories';
+
+class AuthManager {
+  /** @type {AuthServices} */
+  service = null;
+
+  isAuthenticated = false;
+  isAdmin = false;
+
+  constructor(apiFetch) {
+    this.service = new AuthServices({ api: apiFetch });
+  }
+  
+  authenticate = async ({ email, password }) => {
+    // TODO: Update for when this returns the user data and not just true/false.
+    const result = await this.service.auth({ username: email, password });
+
+    if (result) {
+      this.isAuthenticated = true;
+    }
+
+    return result;
+  };
+
+  logout = async () => {
+    const result = await this.service.logout();
+
+    if (result) {
+      this.isAuthenticated = false;
+    }
+
+    return result;
+  };
+
+  getIsAuthenticated = async () => {
+    const result = await this.service.isAuthenticated();
+
+    this.isAuthenticated = result;
+
+    return result;
+  };
+}
+
+export default AuthManager;

--- a/modules/common/package.json
+++ b/modules/common/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@dirtleague/common",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    
+  },
+  "dependencies": {
+    
+  }
+}

--- a/modules/common/src/index.js
+++ b/modules/common/src/index.js
@@ -1,2 +1,4 @@
 export { default as isNil } from './utils/isNil.js';
 export { default as weakMerge } from './utils/weakMerge.js';
+export { default as sleep } from './utils/sleep.js';
+export { default as randomInt } from './utils/randomInt.js';

--- a/modules/common/src/index.js
+++ b/modules/common/src/index.js
@@ -1,0 +1,2 @@
+export { default as isNil } from './utils/isNil.js';
+export { default as weakMerge } from './utils/weakMerge.js';

--- a/modules/common/src/utils/isNil.js
+++ b/modules/common/src/utils/isNil.js
@@ -1,0 +1,3 @@
+const isNil = (obj) => obj === null || obj === undefined;
+
+export default isNil;

--- a/modules/common/src/utils/randomInt.js
+++ b/modules/common/src/utils/randomInt.js
@@ -1,0 +1,5 @@
+const { floor, random } = Math;
+
+const randomInt = (min = 0, max = 1) => floor(random() * (max - min + 1)) + min;
+
+export default randomInt;

--- a/modules/common/src/utils/sleep.js
+++ b/modules/common/src/utils/sleep.js
@@ -1,0 +1,3 @@
+const sleep = (timeout) => new Promise((res) => setTimeout(res, timeout));
+
+export default sleep;

--- a/modules/common/src/utils/weakMerge.js
+++ b/modules/common/src/utils/weakMerge.js
@@ -1,0 +1,16 @@
+import isNil from './isNil.js';
+
+const weakMerge = (left, right) => {
+  return Object
+    .keys(right)
+    .reduce((acc, keyName) => {
+      if (!isNil(right[keyName])) {
+        acc[keyName] = right[keyName];
+      } else if (!isNil(left[keyName])) {
+        acc[keyName] = left[keyName];
+      }
+      return acc;
+    }, {});
+};
+
+export default weakMerge;

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node src/index.js"
+    "start": "set DEBUG=express:* & node src/index.js"
   },
   "dependencies": {
     "@databases/mysql": "5.0.0"
   },
   "devDependencies": {
-    "@databases/mysql-test": "^3.1.0"
+    "@databases/mysql-test": "^3.1.0",
+    "pbkdf2-password": "1.2.1",
+    "express-session": "1.17.1"
   }
 }

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "set DEBUG=express:* & node src/index.js"
+    "start": "set DEBUG=express:* & node src/index.js",
+    "seed": "node ./src/seed-db.js"
   },
   "dependencies": {
     "@databases/mysql": "5.0.0"

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -9,11 +9,12 @@
   },
   "dependencies": {
     "@databases/mysql": "5.0.0",
-    "@dirtleague/common": "*"
+    "@dirtleague/common": "*",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@databases/mysql-test": "^3.1.0",
-    "pbkdf2-password": "1.2.1",
-    "express-session": "1.17.1"
+    "express-session": "1.17.1",
+    "pbkdf2-password": "1.2.1"
   }
 }

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -8,7 +8,8 @@
     "seed": "node ./src/seed-db.js"
   },
   "dependencies": {
-    "@databases/mysql": "5.0.0"
+    "@databases/mysql": "5.0.0",
+    "@dirtleague/common": "*"
   },
   "devDependencies": {
     "@databases/mysql-test": "^3.1.0",

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -10,11 +10,12 @@
   "dependencies": {
     "@databases/mysql": "5.0.0",
     "@dirtleague/common": "*",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "express-session": "1.17.1",
+    "pbkdf2-password": "1.2.1",
+    "jsonwebtoken": "8.5.1"
   },
   "devDependencies": {
-    "@databases/mysql-test": "^3.1.0",
-    "express-session": "1.17.1",
-    "pbkdf2-password": "1.2.1"
+    "@databases/mysql-test": "^3.1.0"
   }
 }

--- a/modules/server/src/auth/handler.js
+++ b/modules/server/src/auth/handler.js
@@ -2,15 +2,6 @@
 import jwt from 'jsonwebtoken';
 import { hashPassword } from '../crypto/hash.js';
 
-export const requireAuth = (req, res, next) => {
-  if (req.session.user) {
-    next();
-  } else {
-    res.status(401);
-    res.json({ error: 'Unauthorized' });
-  }
-};
-
 export const extractToken = (req) => {
   const bearerHeader = req.headers['authorization'];
 

--- a/modules/server/src/auth/handler.js
+++ b/modules/server/src/auth/handler.js
@@ -1,0 +1,41 @@
+/** @typedef {import('../data-access/repositories.js').default} RepositoryServices  */
+import { hashPassword } from '../crypto/hash.js';
+
+export const requireAuth = (req, res, next) => {
+  if (req.session.user) {
+    next();
+  } else {
+    res.status(401);
+    res.json({ error: 'Unauthorized' });
+  }
+};
+
+/**
+ * 
+ * @param {string} username 
+ * @param {string} password 
+ * @param {RepositoryServices} services 
+ */
+export const authenticate = async (username, password, services) => {
+  const user = await services.users.getByEmail(username);
+
+  // query the db for the given username
+  if (!user) {
+    console.log('user not found');
+    return null;
+  }
+
+  console.log(`User  Salt: ${user.password_salt}`);
+
+  const { hash } = await hashPassword(password, user.password_salt);
+
+  console.log(`User  Hash: ${user.password_hash}`);
+  console.log(`Input Hash: ${hash}`);
+
+  if (hash === user.password_hash) {
+    // TODO: Remove password hash and salt.
+    return user;
+  }
+
+  return null;
+};

--- a/modules/server/src/auth/handler.js
+++ b/modules/server/src/auth/handler.js
@@ -21,16 +21,10 @@ export const authenticate = async (username, password, services) => {
 
   // query the db for the given username
   if (!user) {
-    console.log('user not found');
     return null;
   }
 
-  console.log(`User  Salt: ${user.password_salt}`);
-
   const { hash } = await hashPassword(password, user.password_salt);
-
-  console.log(`User  Hash: ${user.password_hash}`);
-  console.log(`Input Hash: ${hash}`);
 
   if (hash === user.password_hash) {
     // TODO: Remove password hash and salt.

--- a/modules/server/src/config/default-config.js
+++ b/modules/server/src/config/default-config.js
@@ -1,0 +1,6 @@
+const config = {
+  sessionSecret: 'go pack go',
+  sqlConnectionString: 'mysql://test-user:password@localhost:3306/test-db'
+};
+
+export default config;

--- a/modules/server/src/config/envvar-config.js
+++ b/modules/server/src/config/envvar-config.js
@@ -1,0 +1,6 @@
+const config = {
+  sessionSecret: process.env.DIRTLEAGUE_SESSION_SECRET,
+  sqlConnectionString: process.env.DIRTLEAGUE_SQL_CONNECTION_STRING,
+};
+
+export default config;

--- a/modules/server/src/config/manager.js
+++ b/modules/server/src/config/manager.js
@@ -1,0 +1,28 @@
+import DefaultConfig from './default-config.js';
+import EnvVarConfig from './envvar-config.js';
+import { weakMerge } from '@dirtleague/common';
+
+class ConfigManager {
+  props = DefaultConfig;
+
+  constructor() {
+    this.props = weakMerge(DefaultConfig, EnvVarConfig);
+
+    console.log(this.props);
+  }
+}
+
+export default ConfigManager;
+
+let instance = null;
+
+/**
+ * @returns {ConfigManager}
+ */
+export const getDefaultConfigManager = () => {
+  if (instance === null) {
+    instance = new ConfigManager();
+  }
+
+  return instance;
+}

--- a/modules/server/src/config/manager.js
+++ b/modules/server/src/config/manager.js
@@ -7,8 +7,6 @@ class ConfigManager {
 
   constructor() {
     this.props = weakMerge(DefaultConfig, EnvVarConfig);
-
-    console.log(this.props);
   }
 }
 

--- a/modules/server/src/crypto/hash.js
+++ b/modules/server/src/crypto/hash.js
@@ -1,0 +1,20 @@
+import hashBuilder from 'pbkdf2-password';
+
+const hasher = hashBuilder({
+  digest: 'sha256'
+});
+
+export const hashPassword = (password, salt) => {
+  return new Promise((resolve, reject) => {
+    hasher({ password, salt }, (err, _pass, _salt, _hash) => {
+      if (err) {
+        reject(err);
+      }
+
+      resolve({
+        hash: _hash,
+        salt: _salt,
+      });
+    });
+  });
+};

--- a/modules/server/src/data-access/database.js
+++ b/modules/server/src/data-access/database.js
@@ -1,10 +1,12 @@
 import createConnectionPool from '@databases/mysql';
+import { getDefaultConfigManager } from '../config/manager.js';
 
-// TODO: build out a function to search for envvars or default to a test string.
-const connectionString = 'mysql://test-user:password@localhost:3306/test-db';
+const configManager = getDefaultConfigManager();
+const connectionString = configManager.props.sqlConnectionString;
 
 const db = createConnectionPool(connectionString);
 
+// Make sure we clean up our mess when the process exists.
 process.once('SIGTERM', () => {
   db.dispose().catch((ex) => {
     console.error(ex);

--- a/modules/server/src/data-access/repositories/users.js
+++ b/modules/server/src/data-access/repositories/users.js
@@ -1,6 +1,7 @@
 /** @typedef {import('../database').default} Database */
 import { sql } from '@databases/mysql';
 
+// TODO: Prevent user hashes and salts from being sent down by service.
 class UsersRepository {
   /** @type {Database} */
   db = null;
@@ -9,25 +10,25 @@ class UsersRepository {
     this.db = db;
   }
 
-  insert = async (email, favoriteColor) => {
+  insert = async (email, passwordHash, passwordSalt) => {
     await this.db.query(sql`
-      INSERT INTO users (email, favorite_color)
-      VALUES (${email}, ${favoriteColor})
+      INSERT INTO users (email, password_hash, password_salt)
+      VALUES (${email}, ${passwordHash}, ${passwordSalt})
     `);
   }
 
-  update = async (email, favoriteColor) => {
+  update = async (email, passwordHash, passwordSalt) => {
     await this.db.query(sql`
       UPDATE users
-      SET favorite_color=${favoriteColor}
+      SET password_hash=${passwordHash}, password_salt=${passwordSalt}
       WHERE email=${email}
     `);
   }
   
-  delete = async (email) => {
+  delete = async (id) => {
     await this.db.query(sql`
       DELETE FROM users
-      WHERE email=${email}
+      WHERE id=${id}
     `);
   }
   
@@ -35,6 +36,17 @@ class UsersRepository {
     const users = await this.db.query(sql`
       SELECT * FROM users
       WHERE id=${id}
+    `);
+    if (users.length === 0) {
+      return null;
+    }
+    return users[0];
+  }
+
+  getByEmail = async (email) => {
+    const users = await this.db.query(sql`
+      SELECT * FROM users
+      WHERE email=${email}
     `);
     if (users.length === 0) {
       return null;

--- a/modules/server/src/data-access/schema/users.js
+++ b/modules/server/src/data-access/schema/users.js
@@ -6,7 +6,8 @@ export const createUsersTable = async (db) => {
     CREATE TABLE IF NOT EXISTS users (
       id SERIAL NOT NULL PRIMARY KEY,
       email VARCHAR(128) NOT NULL,
-      favorite_color VARCHAR(50) NOT NULL,
+      password_hash VARCHAR(256) NOT NULL,
+      password_salt VARCHAR(256) NOT NULL,
       UNIQUE(email)
     )
   `);

--- a/modules/server/src/http/cors-handler.js
+++ b/modules/server/src/http/cors-handler.js
@@ -1,0 +1,9 @@
+import cors from 'cors';
+
+// TODO: Make origins configurable.
+const corsHandler = cors({
+  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+  credentials: true,
+});
+
+export default corsHandler;

--- a/modules/server/src/http/generic-error-handler.js
+++ b/modules/server/src/http/generic-error-handler.js
@@ -1,0 +1,6 @@
+const genericErrorHandler = (err, req, res, next) => {
+  console.error(err.stack);
+  res.status(500).send('Something broke!')
+};
+
+export default genericErrorHandler;

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -3,10 +3,12 @@ import { applyToken } from './auth/handler.js';
 import RepositoryServices from './data-access/repositories.js';
 import buildUsersRoute from './routes/users.js';
 import buildAuthRoute from './routes/auth.js';
-import cors from 'cors';
+import genericErrorHandler from './http/generic-error-handler.js';
+import corsHandler from './http/cors-handler.js';
 
 const app = express();
 const port = 8081; // TODO: Make configurable.
+const services = new RepositoryServices();
 
 /**
  * TODO: Need to add REST API support for
@@ -29,23 +31,14 @@ const port = 8081; // TODO: Make configurable.
  * post(events/import) - { file: UDisc CSV }
  */
 
+// Setup our handlers/middlewares.
 app.use(express.json()) // for parsing application/json
 app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
 app.use(applyToken);
+app.use(genericErrorHandler);
 
-const corsHandler = cors({
-  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
-  credentials: true,
-});
-app.options('*', corsHandler)
-
-// TODO: Move into it's own middleware file.
-app.use((err, req, res, next) => {
-  console.error(err.stack)
-  res.status(500).send('Something broke!')
-});
-
-const services = new RepositoryServices();
+// For now, just tell express that any OPTIONS request should follow the same CORS rules.
+app.options('*', corsHandler);
 
 // Add the routers for each area.
 app.use('/users', buildUsersRoute(services));

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import session from 'express-session';
+import { getDefaultConfigManager } from './config/manager.js';
 import RepositoryServices from './data-access/repositories.js';
 import buildUsersRoute from './routes/users.js';
 import buildAuthRoute from './routes/auth.js';
 
+const configManager = getDefaultConfigManager();
 const app = express();
 const port = 8081;
 
@@ -35,7 +37,7 @@ app.use(express.urlencoded({ extended: true })) // for parsing application/x-www
 app.use(session({
   resave: false, // don't save session if unmodified
   saveUninitialized: false, // don't create session until something stored
-  secret: 'shhhh, very secret'
+  secret: configManager.props.sessionSecret
 }));
 
 app.use(function (err, req, res, next) {

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -1,11 +1,10 @@
 import express from 'express';
-import session from 'express-session';
-import { getDefaultConfigManager } from './config/manager.js';
+import { applyToken } from './auth/handler.js';
 import RepositoryServices from './data-access/repositories.js';
 import buildUsersRoute from './routes/users.js';
 import buildAuthRoute from './routes/auth.js';
+import cors from 'cors';
 
-const configManager = getDefaultConfigManager();
 const app = express();
 const port = 8081; // TODO: Make configurable.
 
@@ -30,29 +29,15 @@ const port = 8081; // TODO: Make configurable.
  * post(events/import) - { file: UDisc CSV }
  */
 
-// app.options('*', cors());
-
-// NOTE: For now, just allow any other domain to access the API.
-// We're not really the most secure thing in the world, but whatever. v2 I guess.
-/*app.use(cors({
-  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
-}));*/
-
 app.use(express.json()) // for parsing application/json
 app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
+app.use(applyToken);
 
-// TODO: Use https://npmjs.com/package/express-mysql-session for prod.
-// The default in-memory session store apparently will leak memory.
-app.use(session({
-  name: 'DIRTY_COOKIE', // TODO: Make configurable.
-  resave: false, // don't save session if unmodified
-  saveUninitialized: false, // don't create session until something stored
-  secret: configManager.props.sessionSecret,
-  cookie: {
-    maxAge: 1000 * 60 * 60 * 24, // one day
-    //sameSite: 'none',
-  },
-}));
+const corsHandler = cors({
+  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+  credentials: true,
+});
+app.options('*', corsHandler)
 
 // TODO: Move into it's own middleware file.
 app.use((err, req, res, next) => {

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -33,14 +33,15 @@ const port = 8081;
 app.use(express.json()) // for parsing application/json
 app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
 
-// TODO: Setup the secret in the config provider.
+// TODO: Use https://npmjs.com/package/express-mysql-session for prod.
+// The default in-memory session store apparently will leak memory.
 app.use(session({
   resave: false, // don't save session if unmodified
   saveUninitialized: false, // don't create session until something stored
   secret: configManager.props.sessionSecret
 }));
 
-app.use(function (err, req, res, next) {
+app.use((err, req, res, next) => {
   console.error(err.stack)
   res.status(500).send('Something broke!')
 });

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -1,7 +1,10 @@
 import express from 'express';
 import RepositoryServices from './data-access/repositories.js';
 import applyUsersRoute from './routes/users.js';
+import hashBuilder from 'pbkdf2-password';
+import session from 'express-session';
 
+const hash = hashBuilder();
 const app = express();
 const port = 8081;
 
@@ -26,9 +29,97 @@ const port = 8081;
  * post(events/import) - { file: UDisc CSV }
  */
 
+app.use(express.json()) // for parsing application/json
+app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
+
+app.use(session({
+  resave: false, // don't save session if unmodified
+  saveUninitialized: false, // don't create session until something stored
+  secret: 'shhhh, very secret'
+}));
+
+app.use(function (err, req, res, next) {
+  console.error(err.stack)
+  res.status(500).send('Something broke!')
+});
+
+app.use(function(req, res, next){
+  var err = req.session.error;
+  var msg = req.session.success;
+  delete req.session.error;
+  delete req.session.success;
+  res.locals.message = '';
+  if (err) res.locals.message = '<p class="msg error">' + err + '</p>';
+  if (msg) res.locals.message = '<p class="msg success">' + msg + '</p>';
+  next();
+});
+
+const users = {
+  ben: { name: 'ben' }
+};
+
+hash({ password: 'foobar' }, function (err, pass, salt, hash) {
+  if (err) throw err;
+  
+  // store the salt & hash in the "db"
+  users.ben.salt = salt;
+  users.ben.hash = hash;
+});
+
+function authenticate(name, pass, fn) {
+  console.log('authenticating %s:%s', name, pass);
+
+  var user = users[name];
+  // query the db for the given username
+  if (!user) return fn(new Error('cannot find user'));
+  // apply the same algorithm to the POSTed password, applying
+  // the hash against the pass / salt, if there is a match we
+  // found the user
+  hash({ password: pass, salt: user.salt }, function (err, pass, salt, hash) {
+    if (err) return fn(err);
+    if (hash === user.hash) return fn(null, user)
+    fn(new Error('invalid password'));
+  });
+}
+
+function restrict(req, res, next) {
+  if (req.session.user) {
+    next();
+  } else {
+    res.status(401);
+    res.json({ error: 'Unauthorized' });
+  }
+}
+
+app.post('/login', (req, res) => {
+  const { username, password, redirect = '/' } = req.body;
+
+  authenticate(username, password, (err, user) => {
+    if (user) {
+      // Regenerate session when signing in
+      // to prevent fixation
+      req.session.regenerate(function(){
+        // Store the user's primary key
+        // in the session store to be retrieved,
+        // or in this case the entire user object
+        req.session.user = user;
+        res.redirect(redirect);
+      });
+    } else {
+      // TODO: Add a random timeout to prevent brute force attacks.
+      res.status(401);
+      res.json({ error: 'Username or password invalid' });
+    }
+  });
+});
+
 const services = new RepositoryServices();
 
 applyUsersRoute(app, services);
+
+app.get('/test', restrict, (req, res) => {
+  res.json({ success: true });
+});
 
 app.listen(port, async () => {
   console.log(`DirtLeague API listening at http://localhost:${port}`);  

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -1,10 +1,9 @@
 import express from 'express';
-import RepositoryServices from './data-access/repositories.js';
-import applyUsersRoute from './routes/users.js';
-import hashBuilder from 'pbkdf2-password';
 import session from 'express-session';
+import RepositoryServices from './data-access/repositories.js';
+import buildUsersRoute from './routes/users.js';
+import buildAuthRoute from './routes/auth.js';
 
-const hash = hashBuilder();
 const app = express();
 const port = 8081;
 
@@ -32,6 +31,7 @@ const port = 8081;
 app.use(express.json()) // for parsing application/json
 app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
 
+// TODO: Setup the secret in the config provider.
 app.use(session({
   resave: false, // don't save session if unmodified
   saveUninitialized: false, // don't create session until something stored
@@ -43,83 +43,11 @@ app.use(function (err, req, res, next) {
   res.status(500).send('Something broke!')
 });
 
-app.use(function(req, res, next){
-  var err = req.session.error;
-  var msg = req.session.success;
-  delete req.session.error;
-  delete req.session.success;
-  res.locals.message = '';
-  if (err) res.locals.message = '<p class="msg error">' + err + '</p>';
-  if (msg) res.locals.message = '<p class="msg success">' + msg + '</p>';
-  next();
-});
-
-const users = {
-  ben: { name: 'ben' }
-};
-
-hash({ password: 'foobar' }, function (err, pass, salt, hash) {
-  if (err) throw err;
-  
-  // store the salt & hash in the "db"
-  users.ben.salt = salt;
-  users.ben.hash = hash;
-});
-
-function authenticate(name, pass, fn) {
-  console.log('authenticating %s:%s', name, pass);
-
-  var user = users[name];
-  // query the db for the given username
-  if (!user) return fn(new Error('cannot find user'));
-  // apply the same algorithm to the POSTed password, applying
-  // the hash against the pass / salt, if there is a match we
-  // found the user
-  hash({ password: pass, salt: user.salt }, function (err, pass, salt, hash) {
-    if (err) return fn(err);
-    if (hash === user.hash) return fn(null, user)
-    fn(new Error('invalid password'));
-  });
-}
-
-function restrict(req, res, next) {
-  if (req.session.user) {
-    next();
-  } else {
-    res.status(401);
-    res.json({ error: 'Unauthorized' });
-  }
-}
-
-app.post('/login', (req, res) => {
-  const { username, password, redirect = '/' } = req.body;
-
-  authenticate(username, password, (err, user) => {
-    if (user) {
-      // Regenerate session when signing in
-      // to prevent fixation
-      req.session.regenerate(function(){
-        // Store the user's primary key
-        // in the session store to be retrieved,
-        // or in this case the entire user object
-        req.session.user = user;
-        res.redirect(redirect);
-      });
-    } else {
-      // TODO: Add a random timeout to prevent brute force attacks.
-      res.status(401);
-      res.json({ error: 'Username or password invalid' });
-    }
-  });
-});
-
 const services = new RepositoryServices();
 
-applyUsersRoute(app, services);
-
-app.get('/test', restrict, (req, res) => {
-  res.json({ success: true });
-});
+// Add the routers for each area.
+app.use('/users', buildUsersRoute(services));
+app.use('/auth', buildAuthRoute(services));
 
 app.listen(port, async () => {
   console.log(`DirtLeague API listening at http://localhost:${port}`);  

--- a/modules/server/src/index.js
+++ b/modules/server/src/index.js
@@ -1,6 +1,5 @@
 import express from 'express';
 import session from 'express-session';
-import cors from 'cors';
 import { getDefaultConfigManager } from './config/manager.js';
 import RepositoryServices from './data-access/repositories.js';
 import buildUsersRoute from './routes/users.js';
@@ -31,9 +30,13 @@ const port = 8081; // TODO: Make configurable.
  * post(events/import) - { file: UDisc CSV }
  */
 
+// app.options('*', cors());
+
 // NOTE: For now, just allow any other domain to access the API.
 // We're not really the most secure thing in the world, but whatever. v2 I guess.
-app.use(cors());
+/*app.use(cors({
+  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+}));*/
 
 app.use(express.json()) // for parsing application/json
 app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
@@ -46,9 +49,9 @@ app.use(session({
   saveUninitialized: false, // don't create session until something stored
   secret: configManager.props.sessionSecret,
   cookie: {
-    maxAge: 1000 * 60 * 60 // one hour
+    maxAge: 1000 * 60 * 60 * 24, // one day
+    //sameSite: 'none',
   },
-  sameSite: false,
 }));
 
 // TODO: Move into it's own middleware file.

--- a/modules/server/src/routes/auth.js
+++ b/modules/server/src/routes/auth.js
@@ -1,0 +1,51 @@
+import express from 'express';
+import { requireAuth, authenticate } from '../auth/handler.js';
+
+const isNil = (obj) => obj === null || obj === undefined;
+
+const buildRoute = (services) => {
+  const router = express.Router();
+
+  router.post('/', async (req, res) => {
+    const { username, password, redirect = '/' } = req.body;
+
+    console.log(`Authenticating ${username}:${password}`);
+
+    const user = await authenticate(username, password, services);
+    
+    if (user) {
+      // Regenerate session when signing in
+      // to prevent fixation
+      req.session.regenerate(function(){
+        // Store the user's primary key
+        // in the session store to be retrieved,
+        // or in this case the entire user object
+        req.session.user = user;
+        res.redirect(redirect);
+      });
+    } else {
+      // TODO: Add a random timeout to prevent brute force attacks.
+      res.status(401);
+      res.json({ error: 'Username or password invalid' });
+    }
+  });
+  
+  router.get('/debug', async (req, res) => {
+    const { user } = req.session;
+    console.log(req.session);
+
+    res.json({
+      isAuthenticated: (isNil(user) ? false : true)
+    });
+  });
+
+  router.get('/test', requireAuth, (req, res) => {
+    res.json({
+      authenticated: true,
+    });
+  });
+
+  return router;
+};
+
+export default buildRoute;

--- a/modules/server/src/routes/auth.js
+++ b/modules/server/src/routes/auth.js
@@ -6,7 +6,7 @@ const buildRoute = (services) => {
   const router = express.Router();
 
   router.post('/', async (req, res) => {
-    const { username, password, redirect = '/' } = req.body;
+    const { username, password } = req.body;
 
     const user = await authenticate(username, password, services);
     
@@ -18,20 +18,27 @@ const buildRoute = (services) => {
         // in the session store to be retrieved,
         // or in this case the entire user object
         req.session.user = user;
-        res.redirect(redirect);
+        res.json({ success: true });
       });
     } else {
       // Add a random sleep into this to prevent someone brute force attacks.
       await sleep(randomInt(1000, 5000));
       res.status(401);
-      res.json({ error: 'Username or password invalid' });
+      res.json({ success: false, error: 'Username or password invalid' });
     }
   });
+
+  router.delete('/', async (req, res) => {
+    req.session.destroy();
+    //res.clearCookie('DIRTY_COOKIE');
+    res.json({ success: true });
+  })
   
-  router.get('/debug', async (req, res) => {
+  router.get('/', async (req, res) => {
     const { user } = req.session;
 
     res.json({
+      success: true,
       isAuthenticated: (isNil(user) ? false : true)
     });
   });

--- a/modules/server/src/routes/auth.js
+++ b/modules/server/src/routes/auth.js
@@ -2,12 +2,7 @@ import express from 'express';
 import jwt from 'jsonwebtoken';
 import { authenticate } from '../auth/handler.js';
 import { randomInt, sleep } from '@dirtleague/common';
-import cors from 'cors';
-
-const corsHandler = cors({
-  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
-  credentials: true,
-});
+import corsHandler from '../http/cors-handler.js';
 
 const buildRoute = (services) => {
   const router = express.Router();

--- a/modules/server/src/routes/auth.js
+++ b/modules/server/src/routes/auth.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import { requireAuth, authenticate } from '../auth/handler.js';
-
-const isNil = (obj) => obj === null || obj === undefined;
+import { isNil } from '@dirtleague/common';
 
 const buildRoute = (services) => {
   const router = express.Router();

--- a/modules/server/src/routes/auth.js
+++ b/modules/server/src/routes/auth.js
@@ -1,11 +1,19 @@
 import express from 'express';
 import { requireAuth, authenticate } from '../auth/handler.js';
 import { isNil, randomInt, sleep } from '@dirtleague/common';
+import cors from 'cors';
+
+const corsHandler = cors({
+  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+  credentials: true,
+});
 
 const buildRoute = (services) => {
   const router = express.Router();
 
-  router.post('/', async (req, res) => {
+  router.options(['/', '/test'], corsHandler);
+
+  router.post('/', corsHandler, async (req, res) => {
     const { username, password } = req.body;
 
     const user = await authenticate(username, password, services);
@@ -32,9 +40,9 @@ const buildRoute = (services) => {
     req.session.destroy();
     //res.clearCookie('DIRTY_COOKIE');
     res.json({ success: true });
-  })
+  });
   
-  router.get('/', async (req, res) => {
+  router.get('/', corsHandler, async (req, res) => {
     const { user } = req.session;
 
     res.json({

--- a/modules/server/src/routes/auth.js
+++ b/modules/server/src/routes/auth.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { requireAuth, authenticate } from '../auth/handler.js';
-import { isNil } from '@dirtleague/common';
+import { isNil, randomInt, sleep } from '@dirtleague/common';
 
 const buildRoute = (services) => {
   const router = express.Router();
@@ -8,14 +8,12 @@ const buildRoute = (services) => {
   router.post('/', async (req, res) => {
     const { username, password, redirect = '/' } = req.body;
 
-    console.log(`Authenticating ${username}:${password}`);
-
     const user = await authenticate(username, password, services);
     
     if (user) {
       // Regenerate session when signing in
       // to prevent fixation
-      req.session.regenerate(function(){
+      req.session.regenerate(() => {
         // Store the user's primary key
         // in the session store to be retrieved,
         // or in this case the entire user object
@@ -23,7 +21,8 @@ const buildRoute = (services) => {
         res.redirect(redirect);
       });
     } else {
-      // TODO: Add a random timeout to prevent brute force attacks.
+      // Add a random sleep into this to prevent someone brute force attacks.
+      await sleep(randomInt(1000, 5000));
       res.status(401);
       res.json({ error: 'Username or password invalid' });
     }
@@ -31,7 +30,6 @@ const buildRoute = (services) => {
   
   router.get('/debug', async (req, res) => {
     const { user } = req.session;
-    console.log(req.session);
 
     res.json({
       isAuthenticated: (isNil(user) ? false : true)

--- a/modules/server/src/routes/users.js
+++ b/modules/server/src/routes/users.js
@@ -1,14 +1,22 @@
-export default function applyRoute(app, services) {
-  app.get('/users', async (req, res) => {
+import express from 'express';
+
+const buildRoute = (services) => {
+  const router = express.Router();
+
+  router.get('/', async (req, res) => {
     const users = await services.users.getAll();
   
     res.json(users);
   });
   
-  app.get('/users/:id', async (req, res) => {
+  router.get('/:id', async (req, res) => {
     const { id } = req.params;
     const user = await services.users.get(id);
   
     res.json(user);
   });
+
+  return router;
 };
+
+export default buildRoute;

--- a/modules/server/src/routes/users.js
+++ b/modules/server/src/routes/users.js
@@ -9,6 +9,8 @@ const corsHandler = cors({
 const buildRoute = (services) => {
   const router = express.Router();
 
+  // router.options(['/', '/:id'], corsHandler);
+
   router.get('/', corsHandler, async (req, res) => {
     const users = await services.users.getAll();
 

--- a/modules/server/src/routes/users.js
+++ b/modules/server/src/routes/users.js
@@ -1,15 +1,8 @@
 import express from 'express';
-import cors from 'cors';
-
-const corsHandler = cors({
-  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
-  credentials: true,
-});
+import corsHandler from '../http/cors-handler.js';
 
 const buildRoute = (services) => {
   const router = express.Router();
-
-  // router.options(['/', '/:id'], corsHandler);
 
   router.get('/', corsHandler, async (req, res) => {
     const users = await services.users.getAll();

--- a/modules/server/src/routes/users.js
+++ b/modules/server/src/routes/users.js
@@ -1,15 +1,23 @@
 import express from 'express';
+import cors from 'cors';
+
+const corsHandler = cors({
+  origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
+  credentials: true,
+});
 
 const buildRoute = (services) => {
   const router = express.Router();
 
-  router.get('/', async (req, res) => {
+  router.get('/', corsHandler, async (req, res) => {
     const users = await services.users.getAll();
+
+    console.log(req.session);
   
     res.json(users);
   });
   
-  router.get('/:id', async (req, res) => {
+  router.get('/:id', corsHandler, async (req, res) => {
     const { id } = req.params;
     const user = await services.users.get(id);
   

--- a/modules/server/src/seed-db.js
+++ b/modules/server/src/seed-db.js
@@ -1,12 +1,25 @@
+import db from './data-access/database.js';
 import { createUsersTable } from './data-access/schema/users.js';
 import RepositoryServices from './data-access/repositories.js';
+import { hashPassword } from './crypto/hash.js'
 
 const services = new RepositoryServices();
 
-const work = async () => {
-  await createUsersTable();
+const insertUser = async (email, password) => {
+  const { hash, salt } = await hashPassword(password);
 
-  await services.users.insert('ben@dirtleague.org', 'blue');
+  await services.users.insert(email, hash, salt);
 };
 
-work().catch(console.error);
+const work = async () => {
+  await createUsersTable(db);
+
+  await insertUser('ben@dirtleague.org', 'foobar');
+  await insertUser('kyle@dirtleague.org', 'foobar');
+  await insertUser('tim@dirtleague.org', 'foobar');
+  await insertUser('pj@dirtleague.org', 'foobar');
+};
+
+work()
+  .then(() => process.exit(0))
+  .catch(console.error);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "client:build": "yarn workspace client build",
     "client:test": "yarn workspace client test",
     "server:start": "yarn workspace server start",
-    "server:mysql-start": "yarn mysql-test start"
+    "server:mysql-start": "yarn mysql-test start",
+    "server:mysql-seed": "yarn workspace server seed"
   },
   "eslintConfig": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4183,6 +4183,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -4952,6 +4957,20 @@ expect@^26.6.0, expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
+express-session@1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.1.tgz#36ecbc7034566d38c8509885c044d461c11bf357"
+  integrity sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-headers "~1.0.2"
+    parseurl "~1.3.3"
+    safe-buffer "5.2.0"
+    uid-safe "~2.1.5"
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -5065,6 +5084,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastfall@^1.2.3:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/fastfall/-/fastfall-1.5.1.tgz#3fee03331a49d1d39b3cdf7a5e9cd66f475e7b94"
+  integrity sha1-P+4DMxpJ0dObPN96XpzWb0dee5Q=
+  dependencies:
+    reusify "^1.0.0"
 
 fastq@^1.6.0:
   version "1.10.1"
@@ -8208,6 +8234,13 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pbkdf2-password@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pbkdf2-password/-/pbkdf2-password-1.2.1.tgz#9f74513a155fd38d4d6b5c8414d3955dd26ca6ee"
+  integrity sha1-n3RROhVf041Na1yEFNOVXdJspu4=
+  dependencies:
+    fastfall "^1.2.3"
+
 pbkdf2@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
@@ -9185,6 +9218,11 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+random-bytes@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/random-bytes/-/random-bytes-1.0.0.tgz#4f68a1dc0ae58bd3fb95848c30324db75d64360b"
+  integrity sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -9653,7 +9691,7 @@ retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-reusify@^1.0.4:
+reusify@^1.0.0, reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
@@ -9766,6 +9804,11 @@ safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
+  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
 safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -10965,6 +11008,13 @@ typescript@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+
+uid-safe@~2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/uid-safe/-/uid-safe-2.1.5.tgz#2b3d5c7240e8fc2e58f8aa269e5ee49c0857bd3a"
+  integrity sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==
+  dependencies:
+    random-bytes "~1.0.0"
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3681,6 +3681,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^5.0.0, cosmiconfig@^5.0.7:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -7813,7 +7821,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -11234,7 +11242,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3082,6 +3082,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -4402,6 +4407,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6996,6 +7008,22 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonwebtoken@8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -7013,6 +7041,23 @@ jsprim@^1.2.2:
   dependencies:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keyboard-key@^1.1.0:
   version "1.1.0"
@@ -7179,10 +7224,45 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Sets up the auth flow with hardcoded values. Currently clicking `log in` will just pass in a value to the API server, and if correct it will return `{ success: true, token: <jwt> }`. There are new express handlers for `applyToken` and `requireToken`, the latter making hiding a resource to authenticated users ez-pz. If we wanted to go hard, we'd add scopes and check those, but that's far beyond what we need at this point. We'll just have a flag for admin in the DB.

The client has a very rough implementation for managing the auth and establishing server communication. This can and should be cleaned up, this was just a good stopping point for this work.